### PR TITLE
Fix copick shortcuts breaking ChimeraX toolbar.

### DIFF
--- a/src/cmd/core.py
+++ b/src/cmd/core.py
@@ -28,9 +28,28 @@ def copick_start(session, config_file: str):
     copick.from_config_file(config_file)
 
 
+def cks(session, shortcut=None):
+    """
+    Enable copick keyboard shortcuts.  Keys typed in the graphics window will be interpreted as shortcuts.
+
+    Parameters
+    ----------
+    shortcut : string
+      Keyboard shortcut to execute.  If no shortcut is specified switch to shortcut input mode.
+    """
+
+    from ..shortcuts.shortcuts import copick_keyboard_shortcuts
+
+    ks = copick_keyboard_shortcuts(session)
+    if shortcut is None:
+        ks.enable_shortcuts()
+    else:
+        ks.try_shortcut(shortcut)
+
+
 def register_copick(logger):
     """Register all commands with ChimeraX, and specify expected arguments."""
-    from chimerax.core.commands import CmdDesc, FileNameArg, register
+    from chimerax.core.commands import CmdDesc, FileNameArg, StringArg, register
 
     def register_copick_start():
         desc = CmdDesc(
@@ -40,4 +59,13 @@ def register_copick(logger):
         )
         register("copick start", desc, copick_start)
 
+    def register_copick_keyboard_shortcuts():
+        desc = CmdDesc(
+            optional=[("shortcut", StringArg)],
+            synopsis="Start using Copick keyboard shortcuts.",
+            # url='help:user/commands/copick_start.html'
+        )
+        register("cks", desc, cks)
+
     register_copick_start()
+    register_copick_keyboard_shortcuts()

--- a/src/shortcuts/shortcuts.py
+++ b/src/shortcuts/shortcuts.py
@@ -6,7 +6,11 @@ from chimerax.artiax.ArtiaX import OPTIONS_PARTLIST_CHANGED
 from chimerax.artiax.particle.ParticleList import delete_selected_particles
 from chimerax.core.session import Session
 from chimerax.log.tool import Log
-from chimerax.shortcuts.shortcuts import Shortcut, keyboard_shortcuts, list_keyboard_shortcuts
+from chimerax.shortcuts.shortcuts import (
+    Keyboard_Shortcuts,
+    Shortcut,
+    shortcut_descriptions,
+)
 
 from ..misc.volops import switch_to_ortho, switch_to_slab
 
@@ -75,8 +79,15 @@ def copick_shortcuts() -> Tuple[List[Tuple[Any, ...]], Tuple[Any, ...]]:
     return csc, catcols
 
 
+def copick_keyboard_shortcuts(session: Session) -> Keyboard_Shortcuts:
+    ks = getattr(session, "copick_shortcuts", None)
+    if ks is None:
+        session.copick_shortcuts = ks = Keyboard_Shortcuts(session)
+    return ks
+
+
 def register_shortcuts(session: Session):
-    ksc = keyboard_shortcuts(session)
+    ksc = copick_keyboard_shortcuts(session)
     ksc.shortcuts.clear()
 
     scs, catcols = copick_shortcuts()
@@ -145,6 +156,11 @@ def toggle_info_label(session: Session):
     session.copick.show_info = not session.copick.show_info
 
 
+def list_copick_shortcuts(session: Session):
+    t = shortcut_descriptions(session.copick_shortcuts, html=True)
+    session.logger.info(t, is_html=True)
+
+
 def show_help(session: Session):
-    list_keyboard_shortcuts(session)
+    list_copick_shortcuts(session)
     session.tools.find_by_class(Log)[0].tool_window.shown = True

--- a/src/tool.py
+++ b/src/tool.py
@@ -48,7 +48,7 @@ class CopickTool(ToolInstance):
     # Does this instance persist when session closes
     SESSION_ENDURING = False
     # We do save/restore in sessions
-    SESSION_SAVE = True
+    SESSION_SAVE = False
 
     # Let ChimeraX know about our help page
     def __init__(self, session, tool_name):
@@ -105,7 +105,7 @@ class CopickTool(ToolInstance):
         from .shortcuts.shortcuts import register_shortcuts
 
         register_shortcuts(self.session)
-        run(session, "ks")
+        run(session, "cks")
 
         # Stepper
         self.stepper_list = []

--- a/src/ui/QCoPickTreeModel.py
+++ b/src/ui/QCoPickTreeModel.py
@@ -93,12 +93,3 @@ class QCoPickTreeModel(QAbstractItemModel):
 
         index.internalPointer()
         return Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsSelectable
-
-        # if item.is_dir:
-        #     return Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsSelectable
-        #
-        # if item.is_file:
-        #     if item.extension in self._openable_types:
-        #         return Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsSelectable
-        #     else:
-        #         return Qt.ItemFlag.ItemIsSelectable


### PR DESCRIPTION
Create a separate shortcut attribute on the session, do not overwrite the existing one. 