### PR TITLE
fix: Ensure lazy loading of all tomograms/voxel spacings, not just the first

### DIFF
--- a/src/ui/QCoPickTreeModel.py
+++ b/src/ui/QCoPickTreeModel.py
@@ -80,6 +80,20 @@ class QCoPickTreeModel(QAbstractItemModel):
 
         return parentItem.has_children  # parentItem.is_dir
 
+    def canFetchMore(self, parent: QModelIndex = ...):
+        parentItem = self._root if not parent.isValid() else parent.internalPointer()
+
+        if parentItem.childCount() == 0:
+            return True
+
+        return False
+
+    def fetchMore(self, parent: QModelIndex = ...):
+        parentItem = self._root if not parent.isValid() else parent.internalPointer()
+
+        if parentItem.childCount() == 0:
+            parentItem.children  # Trigger loading of children
+
     def headerData(self, section, orientation, role=...):
         if orientation == Qt.Orientation.Horizontal and role == Qt.ItemDataRole.DisplayRole:
             if section == 0:

--- a/src/ui/tree.py
+++ b/src/ui/tree.py
@@ -74,7 +74,7 @@ class TreeRun:
         if self._children is None:
             # Don't load children just to count them - return a placeholder count
             # This prevents eager loading while still showing expandable items
-            return 1  # Assume there might be children - will be corrected when expanded
+            return 0  # Assume there might be children - will be corrected when expanded
         return len(self._children)
 
     def childIndex(self) -> Union[int, None]:
@@ -91,11 +91,7 @@ class TreeRun:
 
     @property
     def has_children(self) -> bool:
-        # For lazy loading, assume there might be children without loading them
-        # This will be corrected when the user actually expands the item
-        if self._children is None:
-            return True  # Assume there might be children to show expansion arrow
-        return len(self._children) > 0
+        return True
 
 
 class TreeVoxelSpacing:
@@ -120,7 +116,7 @@ class TreeVoxelSpacing:
     def childCount(self) -> int:
         # For lazy loading, avoid accessing .tomograms unnecessarily
         if self._children is None:
-            return 1  # Assume there might be children - will be corrected when expanded
+            return 0  # Assume there might be children - will be corrected when expanded
         return len(self._children)
 
     def childIndex(self) -> Union[int, None]:
@@ -137,10 +133,7 @@ class TreeVoxelSpacing:
 
     @property
     def has_children(self) -> bool:
-        # For lazy loading, assume there might be children without loading them
-        if self._children is None:
-            return True  # Assume there might be children to show expansion arrow
-        return len(self._children) > 0
+        return True
 
 
 class TreeTomogram:


### PR DESCRIPTION
Adressing a bug in the overhauled main widget. 